### PR TITLE
Adjust wording order in README.md to match KDE Store name

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This project is an enhanced version of the original [Minimal Chaac Weather](http
 
 1. Right-click your taskbar and select Add Widgets.
 2. Click Get New Widgets > Download New Plasma Widgets.
-3. Search for Minimalist Weather Animated and click Install.
+3. Search for Minimalist Animated Weather and click Install.
 
 ### Option 2: Local Installation (Manual)
 


### PR DESCRIPTION
The extension name provided in the description has the words put in the wrong order. Searching it on KDE Store returns 0 results.

This PR fixes the wording order in the README.md to avoid confusion.