### PR TITLE
Add Location Text in Full Representation

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -21,6 +21,9 @@
     <entry name="showConditionExpanded" type="bool">
       <default>true</default>
     </entry>
+    <entry name="showLocationExpanded" type="bool">
+      <default>true</default>
+    </entry>
     <entry name="conditionAlignment" type="int">
       <default>1</default>
     </entry>

--- a/contents/ui/FullRepresentation.qml
+++ b/contents/ui/FullRepresentation.qml
@@ -320,24 +320,50 @@ Item {
 
                 Item { Layout.fillWidth: true; visible: !rootItem.isDesktopMode && !(conditionLabel.visible || rightSideContainer.visible) }
 
-                Row {
+                ColumnLayout {
                     id: tempContainer
                     spacing: 0
                     Layout.alignment: Qt.AlignVCenter
 
-                    PlasmaComponents3.Label {
-                        text: currentTempText
-                        font.pixelSize: Kirigami.Units.gridUnit * 2.5
-                        font.bold: true
-                        leftPadding: currentTempText.length === 1 ? Kirigami.Units.gridUnit * 0.4 : 0
-                        color: Kirigami.Theme.textColor
+                    Row {
+                        spacing: 0
+
+                        PlasmaComponents3.Label {
+                            text: currentTempText
+                            font.pixelSize: Kirigami.Units.gridUnit * 2.5
+                            font.bold: true
+                            leftPadding: currentTempText.length === 1 ? Kirigami.Units.gridUnit * 0.4 : 0
+                            color: Kirigami.Theme.textColor
+                        }
+                        PlasmaComponents3.Label {
+                            text: unitStr
+                            font.pixelSize: Kirigami.Units.gridUnit * 1.5
+                            font.bold: true
+                            topPadding: Kirigami.Units.gridUnit * 0.2
+                            color: Kirigami.Theme.textColor
+                        }
                     }
-                    PlasmaComponents3.Label {
-                        text: unitStr
-                        font.pixelSize: Kirigami.Units.gridUnit * 1.5
-                        font.bold: true
-                        topPadding: Kirigami.Units.gridUnit * 0.2
-                        color: Kirigami.Theme.textColor
+
+                    Row {
+                        spacing: Kirigami.Units.smallSpacing / 2
+                        visible: !!(weatherData && weatherData.city)
+
+                        Kirigami.Icon {
+                            source: "mark-location"
+                            width: Kirigami.Units.gridUnit * 0.8
+                            height: width
+                            color: Kirigami.Theme.textColor
+                            opacity: 0.7
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+
+                        PlasmaComponents3.Label {
+                            text: weatherData && weatherData.city ? weatherData.city : ""
+                            font.pixelSize: Kirigami.Units.gridUnit * 0.7
+                            color: Kirigami.Theme.textColor
+                            opacity: 0.7
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
                     }
                 }
 

--- a/contents/ui/FullRepresentation.qml
+++ b/contents/ui/FullRepresentation.qml
@@ -346,7 +346,7 @@ Item {
 
                     Row {
                         spacing: Kirigami.Units.smallSpacing / 2
-                        visible: !!(weatherData && weatherData.city)
+                        visible: !!(Plasmoid.configuration.showLocationExpanded && weatherData && weatherData.city)
 
                         Kirigami.Icon {
                             source: "mark-location"

--- a/contents/ui/js/DefaultsCatalog.js
+++ b/contents/ui/js/DefaultsCatalog.js
@@ -31,6 +31,7 @@ var APPEARANCE = {
     conditionPanelBold: false,
     preciseTemp: false,
     showConditionExpanded: true,
+    showLocationExpanded: true,
     showAnimations: true,
     hoverDecimals: true,
     xAxisPrecision: true,

--- a/contents/ui/settings/ConfigAppearance.qml
+++ b/contents/ui/settings/ConfigAppearance.qml
@@ -30,6 +30,7 @@ Item {
     property alias cfg_conditionPanelBold:    conditionPanelBoldCheck.checked
     property alias cfg_preciseTemp:           preciseTempCheck.checked
     property alias cfg_showConditionExpanded: showConditionExpandedCheck.checked
+    property alias cfg_showLocationExpanded:  showLocationExpandedCheck.checked
     property alias cfg_conditionAlignment:    conditionAlignmentCombo.currentIndex
     property alias cfg_showAnimations:        showAnimationsCheck.checked
     property alias cfg_hoverDecimals:         hoverDecimalsCheck.checked
@@ -69,6 +70,7 @@ Item {
     property var cfg_longitudeCDefault: undefined
     property var cfg_showConditionPanelDefault: undefined
     property var cfg_showConditionExpandedDefault: undefined
+    property var cfg_showLocationExpandedDefault: undefined
     property var cfg_conditionAlignmentDefault: undefined
     property var cfg_reverseOrderDefault: undefined
     property var cfg_temperatureUnitDefault: undefined
@@ -115,6 +117,7 @@ Item {
         conditionPanelBoldCheck.checked = d.conditionPanelBold;
         preciseTempCheck.checked = d.preciseTemp;
         showConditionExpandedCheck.checked = d.showConditionExpanded;
+        showLocationExpandedCheck.checked = d.showLocationExpanded;
         conditionAlignmentCombo.currentIndex = (d.conditionAlignment !== undefined) ? d.conditionAlignment : 1;
         showAnimationsCheck.checked = d.showAnimations;
         hoverDecimalsCheck.checked = d.hoverDecimals;
@@ -276,6 +279,11 @@ Item {
                             label: i18n("Hover decimals:");
                             CheckBox { id: hoverDecimalsCheck }
                             InfoIcon { text: i18n("Adds one decimal of precision when hovering over the chart, instead of changing in whole numbers.") }
+                        }
+                        SettingRow {
+                            label: i18n("Location Text:");
+                            CheckBox { id: showLocationExpandedCheck }
+                            InfoIcon { text: i18n("Displays the detected location text below the temperature.") }
                         }
                     }
                     rightItem: SettingGroup {

--- a/contents/ui/settings/ConfigData.qml
+++ b/contents/ui/settings/ConfigData.qml
@@ -63,7 +63,9 @@ Item {
     property var cfg_useCoordinatesIpDefault: undefined
     property var cfg_latitudeCDefault: undefined
     property var cfg_longitudeCDefault: undefined
+    property var cfg_showLocationExpanded: undefined
     property var cfg_showConditionPanelDefault: undefined
+    property var cfg_showLocationExpandedDefault: undefined
     property var cfg_showConditionExpandedDefault: undefined
     property var cfg_conditionAlignmentDefault: undefined
     property var cfg_reverseOrderDefault: undefined

--- a/contents/ui/settings/ConfigSource.qml
+++ b/contents/ui/settings/ConfigSource.qml
@@ -80,7 +80,9 @@ Item {
     property var cfg_useCoordinatesIpDefault: undefined
     property var cfg_latitudeCDefault: undefined
     property var cfg_longitudeCDefault: undefined
+    property var cfg_showLocationExpanded: undefined
     property var cfg_showConditionPanelDefault: undefined
+    property var cfg_showLocationExpandedDefault: undefined
     property var cfg_showConditionExpandedDefault: undefined
     property var cfg_conditionAlignmentDefault: undefined
     property var cfg_reverseOrderDefault: undefined

--- a/contents/ui/settings/ConfigSupport.qml
+++ b/contents/ui/settings/ConfigSupport.qml
@@ -85,7 +85,9 @@ Item {
     property var cfg_useCoordinatesIpDefault: undefined
     property var cfg_latitudeCDefault: undefined
     property var cfg_longitudeCDefault: undefined
+    property var cfg_showLocationExpanded: undefined
     property var cfg_showConditionPanelDefault: undefined
+    property var cfg_showLocationExpandedDefault: undefined
     property var cfg_showConditionExpandedDefault: undefined
     property var cfg_conditionAlignmentDefault: undefined
     property var cfg_reverseOrderDefault: undefined


### PR DESCRIPTION
This PR adds a location text, underneath the temperature in the full representation of the widget. 

A corresponding toggle to show/hide the text has been added as well.

<img width="424" height="264" alt="image" src="https://github.com/user-attachments/assets/e6f4735e-3534-46ef-931d-f4a83f28ffc8" />

